### PR TITLE
Fix/tao 4121 repair feature

### DIFF
--- a/controller/PrintTest.php
+++ b/controller/PrintTest.php
@@ -57,7 +57,7 @@ class PrintTest extends tao_actions_CommonModule
         $test           = new core_kernel_classes_Resource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
 
         $model          = $testService->getTestModel($test);
-        if ($model->getUri() != INSTANCE_TEST_MODEL_QTI) {
+        if ($model->getUri() != \taoQtiTest_models_classes_QtiTestService::INSTANCE_TEST_MODEL_QTI) {
             throw new Exception('Not a QTI test');
         }
 

--- a/controller/PrintTest.php
+++ b/controller/PrintTest.php
@@ -67,6 +67,7 @@ class PrintTest extends tao_actions_CommonModule
 
             //generate the pack
             $packer   = new QtiTestPacker();
+            $this->getServiceManager()->propagate($packer);
             $testData = json_encode($packer->packTest($test));
 
             //put the pack in cache

--- a/manifest.php
+++ b/manifest.php
@@ -24,11 +24,11 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '0.2.0',
+    'version'     => '0.3.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
        'tao'          => '>=2.7.3',
-       'taoQtiTest'   => '>=2.6',
+       'taoQtiTest'   => '>=7.0.0',
        'taoQtiPrint' => '>=0.1.0'
     ),
     // for compatibility

--- a/model/BookletGenerator.php
+++ b/model/BookletGenerator.php
@@ -43,7 +43,7 @@ class BookletGenerator
         $report = new common_report_Report(common_report_Report::TYPE_SUCCESS);
 
         $model = \taoTests_models_classes_TestsService::singleton()->getTestModel($test);
-        if ($model->getUri() != INSTANCE_TEST_MODEL_QTI) {
+        if ($model->getUri() != \taoQtiTest_models_classes_QtiTestService::INSTANCE_TEST_MODEL_QTI) {
             $report->setType(common_report_Report::TYPE_ERROR);
             $report->setMessage(__('%s is not a QTI test', $test->getLabel()));
             return $report;

--- a/model/BookletRenderer.php
+++ b/model/BookletRenderer.php
@@ -40,7 +40,7 @@ class BookletGenerator
         $report = new common_report_Report(common_report_Report::TYPE_SUCCESS);
 
         $model = \taoTests_models_classes_TestsService::singleton()->getTestModel($test);
-        if ($model->getUri() != INSTANCE_TEST_MODEL_QTI) {
+        if ($model->getUri() != \taoQtiTest_models_classes_QtiTestService::INSTANCE_TEST_MODEL_QTI) {
             $report->setType(common_report_Report::TYPE_ERROR);
             $report->setMessage(__('%s is not a QTI test', $test->getLabel()));
             return $report;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -20,28 +20,20 @@
  */
 namespace oat\taoBooklet\scripts\update;
 
-use oat\tao\scripts\update\OntologyUpdater;
-use oat\tao\model\entryPoint\EntryPointService;
-
 /**
- * 
+ *
  * @author Joel Bout <joel@taotesting.com>
  */
 class Updater extends \common_ext_ExtensionUpdater {
-    
+
     /**
-     * 
-     * @param string $currentVersion
+     *
+     * @param string $initialVersion
      * @return string $versionUpdatedTo
      */
     public function update($initialVersion) {
-        
-        $currentVersion = $initialVersion;
-        
-        // new menu structure
-        if ($currentVersion == '0.1') {
-            $currentVersion = '0.2.0';
-        }
-        return $currentVersion;
+
+        $this->skip('0.1.0','0.3.0');
+
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4121

Requires: https://github.com/oat-sa/extension-tao-qtiprint/pull/17

Fix the extension:
- use the new constants from taoQtiTest, as the legacy constants have disappeared
- modernize the updater

To be able to generate the booklet, you must install wkHTMLtoPDF.
If you are using Ubuntu, you can try this:
```bash
sudo apt-get update
sudo apt-get install wkhtmltopdf
```

However, if you fall to a QT error, you should prefer this method to get the patched version of the tool:

```bash
sudo apt-get update
sudo apt-get install libxrender1 fontconfig xvfb
wget http://download.gna.org/wkhtmltopdf/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -P /tmp/
cd /usr/share/
sudo tar xf /tmp/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
sudo rm /usr/local/bin/wkhtmltopdf
sudo ln -s /usr/share/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
```