### PR TITLE
Fix/tao 4412 booklet cache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.4.0',
+    'version'     => '1.4.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'           => '>=10.2.0',

--- a/model/BookletDataService.php
+++ b/model/BookletDataService.php
@@ -24,6 +24,7 @@
 namespace oat\taoBooklet\model;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\service\StateStorage;
 
 /**
  * Class BookletDataService
@@ -32,31 +33,32 @@ use oat\oatbox\service\ConfigurableService;
 class BookletDataService extends ConfigurableService
 {
     const SERVICE_ID = 'taoBooklet/BookletDataService';
-    const CACHE_PREFIX = 'booklet_data_';
+    const STORAGE_PREFIX = 'booklet_data_';
+    const STORAGE_USER = 'BookletUser';
 
     /**
-     * @var \common_cache_Cache
+     * @var StateStorage
      */
-    protected $cache;
+    protected $storage;
 
     /**
-     * @return \common_cache_Cache
+     * @return StateStorage
      */
-    protected function getCache()
+    protected function getStorage()
     {
-        if (!isset($this->cache)) {
-            $this->cache = $this->getServiceManager()->get('generis/cache');
+        if (!isset($this->storage)) {
+            $this->storage = $this->getServiceManager()->get('tao/stateStorage');
         }
-        return $this->cache;
+        return $this->storage;
     }
 
     /**
      * @param string $key
      * @return string
      */
-    protected function getCacheKey($key)
+    protected function getStorageKey($key)
     {
-        return self::CACHE_PREFIX . $key;
+        return self::STORAGE_PREFIX . $key;
     }
 
     /**
@@ -65,11 +67,11 @@ class BookletDataService extends ConfigurableService
      */
     public function getData($key)
     {
-        $cache = $this->getCache();
-        $entry = $this->getCacheKey($key);
+        $storage = $this->getStorage();
+        $entry = $this->getStorageKey($key);
 
-        if ($cache->has($entry)) {
-            return json_decode($cache->get($entry), true);
+        if ($storage->has(self::STORAGE_USER, $entry)) {
+            return json_decode($storage->get(self::STORAGE_USER, $entry), true);
         }
         return null;
     }
@@ -81,7 +83,7 @@ class BookletDataService extends ConfigurableService
      */
     public function setData($key, $data)
     {
-        $this->getCache()->put(json_encode($data), $this->getCacheKey($key));
+        $this->getStorage()->set(self::STORAGE_USER, $this->getStorageKey($key), json_encode($data));
         return $this;
     }
 
@@ -91,11 +93,11 @@ class BookletDataService extends ConfigurableService
      */
     public function cleanData($key)
     {
-        $cache = $this->getCache();
-        $entry = $this->getCacheKey($key);
+        $storage = $this->getStorage();
+        $entry = $this->getStorageKey($key);
 
-        if ($cache->has($entry)) {
-            $cache->remove($entry);
+        if ($storage->has(self::STORAGE_USER, $entry)) {
+            $storage->del(self::STORAGE_USER, $entry);
         }
         return $this;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -105,5 +105,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('1.4.0');
         }
+
+        $this->skip('1.4.0', '1.4.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4412

The booklet is using a cache on the server to share content between the task worker and the booklet renderer page. However, the `generis/cache` is not shared accros servers.

This PR switch the cache to `StateStorage`. 

Note: the `StateStorage` needs a user identifier, to prefix the storage key, and the renderer is called as anonymous while the worker is called in CLI. So an arbitrary user identifier is utilized: `BookletUser`.