### PR TITLE
Fix/tao 4412 booklet storage

### DIFF
--- a/controller/PrintTest.php
+++ b/controller/PrintTest.php
@@ -31,7 +31,6 @@ namespace oat\taoBooklet\controller;
 use common_ext_ExtensionsManager;
 use oat\taoBooklet\model\BookletDataService;
 use tao_actions_CommonModule;
-use tao_helpers_Uri;
 
 /**
  * Class PrintTest
@@ -46,10 +45,9 @@ class PrintTest extends tao_actions_CommonModule
     {
         session_write_close();
 
-        $bookletUri = tao_helpers_Uri::decode($this->getRequestParameter('uri'));
-
-        $cache = $this->getServiceManager()->get(BookletDataService::SERVICE_ID);
-        $bookletData = $cache->getData($bookletUri);
+        $storageKey = $this->getRequestParameter('token');
+        $storageService = $this->getServiceManager()->get(BookletDataService::SERVICE_ID);
+        $bookletData = $storageService->getData($storageKey);
 
         if (!$bookletData) {
             $bookletData = [

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.4.0',
+    'version'     => '1.4.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'           => '>=10.2.0',

--- a/model/BookletDataService.php
+++ b/model/BookletDataService.php
@@ -33,7 +33,7 @@ use oat\oatbox\service\ConfigurableService;
  */
 class BookletDataService extends ConfigurableService
 {
-    const SERVICE_ID = 'taoBooklet/BookletDataService';
+    const SERVICE_ID = 'taoBooklet/bookletDataService';
     const FILE_SYSTEM_ID = 'sharedTmp';
     const STORAGE_PREFIX = 'booklet_data_';
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -106,6 +106,14 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('1.4.0');
         }
 
-        $this->skip('1.4.0', '1.4.1');
+        if ($this->isVersion('1.4.0')) {
+
+            $bookletDataService = new BookletDataService();
+            $this->getServiceManager()->propagate($bookletDataService);
+            $this->getServiceManager()->register(BookletDataService::SERVICE_ID, $bookletDataService);
+
+            $this->setVersion('1.4.1');
+        }
+
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -105,5 +105,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('1.4.0');
         }
+
+        $this->skip('1.4.0', '1.4.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4412

The booklet is using a cache on the server to share content between the task worker and the booklet renderer page. However, the `generis/cache` is not shared accros servers.

This PR switch the cache to `sharedTmp` file system. 
