### PR TITLE
Fix/tao 4412 broken preview

### DIFF
--- a/controller/Booklet.php
+++ b/controller/Booklet.php
@@ -51,7 +51,7 @@ use tao_models_classes_dataBinding_GenerisFormDataBinder;
 class Booklet extends tao_actions_SaSModule
 {
     use OntologyAwareTrait;
-    
+
     public function __construct()
     {
         $this->service = BookletClassService::singleton();
@@ -114,19 +114,17 @@ class Booklet extends tao_actions_SaSModule
         $this->setView( 'Booklet/edit.tpl' );
     }
 
-    public function preview(){
-        $configService = $this->getServiceManager()->get(BookletConfigService::SERVICE_ID);
+    /**
+     * @throws \common_Exception
+     */
+    public function preview()
+    {
         $instance = $this->getCurrentInstance();
         $test     = $this->getClassService()->getTest( $instance );
-        $config   = $configService->getConfig($instance);
-
         if(is_null($test)){
             throw new \common_Exception('No test linked to the booklet');
         }
-        $url = tao_helpers_Uri::url( 'render', 'PrintTest', 'taoBooklet', array(
-            'uri' => $test->getUri(),
-            'config' => base64_encode(json_encode($config)),
-        ) );
+        $url = tao_helpers_Uri::url( 'preview', 'PrintTest', 'taoBooklet', ['uri' => tao_helpers_Uri::encode($instance->getUri())]);
 
         $this->setData( 'renderUrl', $url);
         $this->setView( 'Booklet/preview.tpl');

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.4.1',
+    'version'     => '1.4.2',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'           => '>=10.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -115,5 +115,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('1.4.1');
         }
 
+        $this->skip('1.4.1', '1.4.2');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4412

The rendering page of the booklet has been changed to use a cached content. However that broke the preview page in the booklet authoring. 