### PR TITLE
Fix/composer taskqueue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "minimum-stability" : "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "dev-master",
-        "oat-sa/lib-oatbox-taskqueue": "dev-master",
         "mikehaertl/phpwkhtmltopdf": "dev-master",
         "tecnickcom/tcpdf" : "dev-master"
     },

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.5.0',
+    'version'     => '1.5.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'          => '>=10.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -135,5 +135,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('1.5.0');
         }
+
+        $this->skip('1.5.0', '1.5.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4318

Remove the dependency to the lib `lib-oatbox-taskqueue`  from the composer.
This dependency should be set in the deploy composer instead.