### PR TITLE
Fix/tao 4770 rendering hang

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.5.1',
+    'version'     => '1.5.2',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'          => '>=10.2.0',

--- a/model/export/PdfBookletExporter.php
+++ b/model/export/PdfBookletExporter.php
@@ -57,15 +57,18 @@ class PdfBookletExporter extends BookletExporter
         //the default options
         $options = array(
 
+            //as the page is built in JS, the engine is waiting for
+            //window.status to equal 'runner-ready' to capture the content
+            //*** Disabled as the current version of wkhtmltopdf is suffering an issue     ***
+            //*** that sometimes prevents the process to be aware of window-status change. ***
+            //'window-status' => 'DONE',
+
+
             //set javascript behavior
             'enable-javascript',
             'debug-javascript',
             'no-stop-slow-scripts',
-            'javascript-delay' => 12000,
-
-            //as the page is built in JS, the engine is waiting for
-            //window.status to equal 'runner-ready' to capture the content
-            'window-status' => 'runner-ready',
+            'javascript-delay' => 15000, // will wait for 15s before considering the content fully rendered
 
             //enable browser media print
             'print-media-type',

--- a/model/export/PdfBookletExporter.php
+++ b/model/export/PdfBookletExporter.php
@@ -57,22 +57,28 @@ class PdfBookletExporter extends BookletExporter
         //the default options
         $options = array(
 
+            //set javascript behavior
+            'enable-javascript',
+            'debug-javascript',
+            'no-stop-slow-scripts',
+            'javascript-delay' => 12000,
+
             //as the page is built in JS, the engine is waiting for
             //window.status to equal 'runner-ready' to capture the content
             'window-status' => 'runner-ready',
-            'javascript-delay' => 12000,
 
             //enable browser media print
             'print-media-type',
 
-            'no-stop-slow-scripts',
+            //set errors handling
             'load-error-handling' => 'ignore',
+            'load-media-error-handling' => 'ignore',
 
-            'dpi'   => 300,
-
+            //print resolution
+            'dpi' => 300,
 
             //document title
-            'title'         => $title,
+            'title' => $title,
 
         );
 
@@ -80,8 +86,6 @@ class PdfBookletExporter extends BookletExporter
         if(is_array($config['options'])){
             $options = array_merge($options, $config['options']);
         }
-
-        $options['replace']['config'] = base64_encode(json_encode($bookletConfig));
 
         if (isset($bookletConfig[BookletConfigService::CONFIG_LAYOUT])) {
             $layoutConfig = $bookletConfig[BookletConfigService::CONFIG_LAYOUT];
@@ -91,6 +95,10 @@ class PdfBookletExporter extends BookletExporter
             if (empty($layoutConfig[BookletConfigService::CONFIG_PAGE_FOOTER])) {
                 unset($options['footer-html']);
             }
+        }
+
+        if (isset($options['header-html']) || isset($options['footer-html'])) {
+            $options['replace']['config'] = base64_encode(json_encode($bookletConfig));
         }
 
         //instantiate the PDF wrapper

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -136,6 +136,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('1.5.0');
         }
 
-        $this->skip('1.5.0', '1.5.1');
+        $this->skip('1.5.0', '1.5.2');
     }
 }

--- a/views/js/controller/PrintTest/render.js
+++ b/views/js/controller/PrintTest/render.js
@@ -143,7 +143,7 @@ define([
              * to tell the 3rd part tool that the page is ready.
              */
             function ready() {
-                window.status = 'runner-ready';
+                window.status = 'DONE';
             }
 
             //we attach the container to the DOM


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4770

Sometimes the rendering of a booklet hangs infinitely. This seems to be due to a bug in `wkhtmltopdf`, related to the `window-status` option. The tool sometimes fails to detect a change in the window status bar. The development version of the tool may have addressed the issue, but it is not already released.

To counter the problem, I temporarily deactivated the `window-status` option, and set the javascript wait delay to 15 seconds. This means each rendering will take always 15 seconds, despite the booklet contains only a few items. That also means if the booklet is very complex, the rendering could fail. However, the previous options set were applying this rule: wait for `window-status` change, or for a maximum of 12 seconds. So I think the workaround will just force a longer execution for every booklet.

There is also some other tools that could replace `wkhtmltopdf`, based either on phantomjs or a headless Chrome, at the price of some refactoring or a custom development:
- [DeckTape](https://github.com/astefanutti/decktape)
- [CaptureJS](https://github.com/superbrothers/capturejs)
- [rasterize.js](http://phantomjs.org/screen-capture.html)
- [PhpChromeToPdf](https://github.com/daudmalik06/PhpChromeToPdf)
- [AthenaPDF](https://github.com/arachnys/athenapdf)