### PR TITLE
Feature/tao 4793 booklet multiple deliveries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "dev-master",
         "mikehaertl/phpwkhtmltopdf": "dev-master",
-        "tecnickcom/tcpdf" : "dev-master"
+        "tecnickcom/tcpdf" : "dev-master",
+        "jurosh/pdf-merge": "dev-master"
     },
     "autoload" : {
         "psr-4" : {

--- a/controller/Booklet.php
+++ b/controller/Booklet.php
@@ -116,7 +116,7 @@ class Booklet extends AbstractBookletController
     {
         $instance  = $this->getCurrentInstance();
 
-        $task = $this->getServiceManager()->get(BookletTaskService::SERVICE_ID)->createBookletTask($instance);
+        $task = $this->getServiceManager()->get(BookletTaskService::SERVICE_ID)->createPrintBookletTask($instance);
 
         $report = $this->getTaskReport($task);
 
@@ -247,7 +247,7 @@ class Booklet extends AbstractBookletController
         $binder = new tao_models_classes_dataBinding_GenerisFormDataBinder($instance);
         $binder->bind($form->getValues());
 
-        $this->getServiceManager()->get(BookletTaskService::SERVICE_ID)->createBookletTask($instance);
+        $this->getServiceManager()->get(BookletTaskService::SERVICE_ID)->createPrintBookletTask($instance);
 
         // return report with instance
         $report->setMessage(__('Booklet %s created', $instance->getLabel()));

--- a/controller/Results.php
+++ b/controller/Results.php
@@ -83,7 +83,7 @@ class Results extends AbstractBookletController
         if ($form->isValid() && $form->isSubmited()) {
             $values = $form->getValues();
 
-            $task = $bookletTaskService->createPrintResultsTask($delivery, $resultId, $values);
+            $task = $bookletTaskService->createPrintResultsTask($this->getResource($resultId), $values);
             $report = $this->getTaskReport($task);
 
             if (!$asyncQueue) {

--- a/manifest.php
+++ b/manifest.php
@@ -24,12 +24,12 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.6.0',
+    'version'     => '1.7.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'          => '>=10.2.0',
         'taoQtiTest'   => '>=7.0.0',
-        'taoQtiPrint'  => '>=1.2.0',
+        'taoQtiPrint'  => '>=1.4.0',
         'taoOutcomeUi' => '>=4.5.0',
     ),
     // for compatibility

--- a/model/BookletClassService.php
+++ b/model/BookletClassService.php
@@ -52,6 +52,7 @@ class BookletClassService extends tao_models_classes_ClassService
     const INSTANCE_COVER_PAGE_DATE = 'http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageDate';
     const INSTANCE_COVER_PAGE_LOGO = 'http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageLogo';
     const INSTANCE_COVER_PAGE_QRCODE = 'http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageQRCode';
+    const INSTANCE_COVER_PAGE_UNIQUE_ID = 'http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageUniqueId';
 
     const INSTANCE_PAGE_LOGO = 'http://www.tao.lu/Ontologies/Booklet.rdf#PageLogo';
     const INSTANCE_PAGE_TITLE = 'http://www.tao.lu/Ontologies/Booklet.rdf#PageTitle';
@@ -59,6 +60,7 @@ class BookletClassService extends tao_models_classes_ClassService
     const INSTANCE_PAGE_LINK = 'http://www.tao.lu/Ontologies/Booklet.rdf#PageLink';
     const INSTANCE_PAGE_DATE = 'http://www.tao.lu/Ontologies/Booklet.rdf#PageDate';
     const INSTANCE_PAGE_NUMBER = 'http://www.tao.lu/Ontologies/Booklet.rdf#PageNumber';
+    const INSTANCE_PAGE_UNIQUE_ID = 'http://www.tao.lu/Ontologies/Booklet.rdf#PageUniqueId';
 
     /**
      * (non-PHPdoc)

--- a/model/BookletConfigService.php
+++ b/model/BookletConfigService.php
@@ -52,6 +52,7 @@ class BookletConfigService extends ConfigurableService
     const CONFIG_MENTION = 'mention';
     const CONFIG_LINK = 'link';
     const CONFIG_PAGE_NUMBER = 'page_number';
+    const CONFIG_UNIQUE_ID = 'unique_id';
 
     /**
      * Maps the properties to config names
@@ -78,6 +79,7 @@ class BookletConfigService extends ConfigurableService
         BookletClassService::INSTANCE_COVER_PAGE_DATE => self::CONFIG_DATE,
         BookletClassService::INSTANCE_COVER_PAGE_LOGO => self::CONFIG_LOGO,
         BookletClassService::INSTANCE_COVER_PAGE_QRCODE => self::CONFIG_QRCODE,
+        BookletClassService::INSTANCE_COVER_PAGE_UNIQUE_ID => self::CONFIG_UNIQUE_ID,
 
         BookletClassService::INSTANCE_PAGE_LOGO => self::CONFIG_LOGO,
         BookletClassService::INSTANCE_PAGE_TITLE => self::CONFIG_TITLE,
@@ -85,6 +87,7 @@ class BookletConfigService extends ConfigurableService
         BookletClassService::INSTANCE_PAGE_LINK => self::CONFIG_LINK,
         BookletClassService::INSTANCE_PAGE_DATE => self::CONFIG_DATE,
         BookletClassService::INSTANCE_PAGE_NUMBER => self::CONFIG_PAGE_NUMBER,
+        BookletClassService::INSTANCE_PAGE_UNIQUE_ID => self::CONFIG_UNIQUE_ID,
     ];
 
     /**
@@ -153,6 +156,7 @@ class BookletConfigService extends ConfigurableService
             self::CONFIG_REGULAR => false,
             self::CONFIG_TITLE => $this->getPropertyValue($properties, RDFS_LABEL),
             self::CONFIG_DESCRIPTION => $this->getPropertyValue($properties, BookletClassService::PROPERTY_DESCRIPTION),
+            self::CONFIG_UNIQUE_ID => strtoupper(dechex(crc32(uniqid())))
         ];
 
         if (isset($properties[BookletClassService::PROPERTY_LAYOUT])) {

--- a/model/BookletConfigService.php
+++ b/model/BookletConfigService.php
@@ -156,7 +156,7 @@ class BookletConfigService extends ConfigurableService
             self::CONFIG_REGULAR => false,
             self::CONFIG_TITLE => $this->getPropertyValue($properties, RDFS_LABEL),
             self::CONFIG_DESCRIPTION => $this->getPropertyValue($properties, BookletClassService::PROPERTY_DESCRIPTION),
-            self::CONFIG_UNIQUE_ID => strtoupper(dechex(crc32(uniqid())))
+            self::CONFIG_UNIQUE_ID => strtoupper(dechex(crc32(uniqid(microtime(), true))))
         ];
 
         if (isset($properties[BookletClassService::PROPERTY_LAYOUT])) {

--- a/model/BookletTaskService.php
+++ b/model/BookletTaskService.php
@@ -29,7 +29,7 @@ use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\task\Queue;
 use oat\oatbox\task\Task;
 use oat\taoBooklet\model\tasks\PrintResults;
-use oat\taoBooklet\model\tasks\UpdateBooklet;
+use oat\taoBooklet\model\tasks\PrintBooklet;
 use oat\Taskqueue\Persistence\RdsQueue;
 
 class BookletTaskService extends ConfigurableService
@@ -67,9 +67,9 @@ class BookletTaskService extends ConfigurableService
      * @param core_kernel_classes_Resource $resource
      * @return Task created task id
      */
-    public function createBookletTask(core_kernel_classes_Resource $resource)
+    public function createPrintBookletTask(core_kernel_classes_Resource $resource)
     {
-        $action = new UpdateBooklet();
+        $action = new PrintBooklet();
         $this->getServiceManager()->propagate($action);
         $queueParameters = [
             'uri' => $resource->getUri(),

--- a/model/BookletTaskService.php
+++ b/model/BookletTaskService.php
@@ -28,6 +28,7 @@ use core_kernel_classes_Resource;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\task\Queue;
 use oat\oatbox\task\Task;
+use oat\taoBooklet\model\tasks\PrintDelivery;
 use oat\taoBooklet\model\tasks\PrintResults;
 use oat\taoBooklet\model\tasks\PrintBooklet;
 use oat\taoDelivery\model\execution\ServiceProxy;
@@ -64,7 +65,7 @@ class BookletTaskService extends ConfigurableService
     }
 
     /**
-     * Create task in queue
+     * Creates a task that will generate a Booklet PDF from an AssessmentTest
      * @param core_kernel_classes_Resource $resource
      * @return Task created task id
      */
@@ -82,7 +83,7 @@ class BookletTaskService extends ConfigurableService
     }
 
     /**
-     * Create task in queue
+     * Creates a task that will generate a Booklet PDF from a DeliveryExecution
      * @param core_kernel_classes_Resource $resource
      * @param array $printConfig
      * @return Task created task id
@@ -109,6 +110,33 @@ class BookletTaskService extends ConfigurableService
             $label .= ' - ' . $printConfig[BookletClassService::PROPERTY_DESCRIPTION];
         }
         $task = $this->getQueueService()->createTask($action, $queueParameters, false, $label, $delivery->getUri());
+
+        return $task;
+    }
+
+    /**
+     * Creates a task that will generate a Booklet PDF from a Delivery
+     * @param core_kernel_classes_Resource $resource
+     * @param array $printConfig
+     * @return Task created task id
+     */
+    public function createPrintDeliveryTask(core_kernel_classes_Resource $resource, $printConfig)
+    {
+        $action = new PrintDelivery();
+        $this->getServiceManager()->propagate($action);
+        
+        $queueParameters = [
+            'uri' => $resource->getUri(),
+            'user' => common_session_SessionManager::getSession()->getUserUri(),
+            'config' => $printConfig,
+        ];
+
+        $label = $resource->getLabel();
+        if (isset($printConfig[RDFS_LABEL])) {
+            $label = $printConfig[RDFS_LABEL];
+        }
+        
+        $task = $this->getQueueService()->createTask($action, $queueParameters, false, $label, $resource->getUri());
 
         return $task;
     }

--- a/model/export/PdfBookletExporter.php
+++ b/model/export/PdfBookletExporter.php
@@ -162,12 +162,14 @@ class PdfBookletExporter extends BookletExporter
     }
 
     /**
-     * Ensures the content is an array of data
+     * Puts the actual content into the pages
      */
-    protected function forceArrayContent()
+    protected function contentToPages()
     {
-        if (!is_array($this->_content)) {
-            $this->_content = $this->_content ? [$this->_content] : [];
+        if (is_array($this->_content)) {
+            foreach($this->_content as $content) {
+                $this->pdf->addPage($content);
+            }
         }
     }
 
@@ -180,7 +182,7 @@ class PdfBookletExporter extends BookletExporter
      */
     public function setContent($content)
     {
-        $this->_content = $this->filterContent($content);
+        $this->_content = [$this->filterContent($content)];
         return $this;
     }
     
@@ -193,11 +195,7 @@ class PdfBookletExporter extends BookletExporter
      */
     public function addContent($content)
     {
-        $content = $this->filterContent($content);
-        
-        $this->forceArrayContent();
-        
-        $this->_content[] = $content;
+        $this->_content[] = $this->filterContent($content);
         return $this;
     }
 
@@ -210,10 +208,7 @@ class PdfBookletExporter extends BookletExporter
      */
     public function saveAs($path)
     {
-        $this->forceArrayContent();
-        foreach($this->_content as $content) {
-            $this->pdf->addPage($content);
-        }
+        $this->contentToPages();
 
         $result = $this->pdf->saveAs($path);
         if(!$result){
@@ -232,7 +227,7 @@ class PdfBookletExporter extends BookletExporter
      */
     public function export($filename = null)
     {
-        $this->pdf->addPage($this->_content);
+        $this->contentToPages();
 
         $result = $this->pdf->send($filename);
         if(!$result){

--- a/model/tasks/PrintBooklet.php
+++ b/model/tasks/PrintBooklet.php
@@ -31,10 +31,10 @@ use taoQtiTest_models_classes_QtiTestService;
 use taoTests_models_classes_TestsService;
 
 /**
- * Class UpdateBooklet
+ * Class PrintBooklet
  * @package oat\taoBooklet\model\tasks
  */
-class UpdateBooklet extends AbstractBookletTask
+class PrintBooklet extends AbstractBookletTask
 {
     /**
      * @var BookletClassService

--- a/model/tasks/PrintBooklet.php
+++ b/model/tasks/PrintBooklet.php
@@ -60,7 +60,7 @@ class PrintBooklet extends AbstractBookletTask
     }
 
     /**
-     * @return JsonSerializable
+     * @return array
      * @throws \Exception
      */
     protected function getTestData()
@@ -75,7 +75,9 @@ class PrintBooklet extends AbstractBookletTask
 
         $packer = new QtiTestPacker();
         $this->getServiceManager()->propagate($packer);
-        return $packer->packTest($test);
+        return [
+            $packer->packTest($test)
+        ];
     }
 
     /**

--- a/model/tasks/PrintBooklet.php
+++ b/model/tasks/PrintBooklet.php
@@ -17,12 +17,14 @@
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  *
  */
+
 /**
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 
 namespace oat\taoBooklet\model\tasks;
 
+use core_kernel_classes_Resource;
 use JsonSerializable;
 use oat\taoBooklet\model\BookletClassService;
 use oat\taoBooklet\model\BookletConfigService;
@@ -51,22 +53,25 @@ class PrintBooklet extends AbstractBookletTask
 
     /**
      * Gets the config for a booklet instance using either the instance itself or an array of properties
+     * @param core_kernel_classes_Resource $instance
      * @return mixed
      */
-    protected function getBookletConfig()
+    protected function getBookletConfig($instance)
     {
         $configService = $this->getServiceLocator()->get(BookletConfigService::SERVICE_ID);
-        return $configService->getConfig($this->getInstance());
+        return $configService->getConfig($instance);
     }
 
     /**
-     * @return JsonSerializable
+     * Gets the test definition data in order to print it
+     * @param core_kernel_classes_Resource $instance
+     * @return JsonSerializable|array
      * @throws \Exception
      */
-    protected function getTestData()
+    protected function getTestData($instance)
     {
         $testService = taoTests_models_classes_TestsService::singleton();
-        $test = $this->bookletClassService->getTest($this->getInstance());
+        $test = $this->bookletClassService->getTest($instance);
 
         $model = $testService->getTestModel($test);
         if ($model->getUri() != taoQtiTest_models_classes_QtiTestService::INSTANCE_TEST_MODEL_QTI) {
@@ -79,12 +84,14 @@ class PrintBooklet extends AbstractBookletTask
     }
 
     /**
+     * Stores the generated PDF file
+     * @param core_kernel_classes_Resource $instance
      * @param string $filePath
      * @return \common_report_Report
      */
-    protected function storePdf($filePath)
+    protected function storePdf($instance, $filePath)
     {
-        return $this->bookletClassService->updateInstanceAttachment($this->getInstance(), $filePath);
+        return $this->bookletClassService->updateInstanceAttachment($instance, $filePath);
     }
 
     /**

--- a/model/tasks/PrintBooklet.php
+++ b/model/tasks/PrintBooklet.php
@@ -60,7 +60,7 @@ class PrintBooklet extends AbstractBookletTask
     }
 
     /**
-     * @return array
+     * @return JsonSerializable
      * @throws \Exception
      */
     protected function getTestData()
@@ -75,9 +75,7 @@ class PrintBooklet extends AbstractBookletTask
 
         $packer = new QtiTestPacker();
         $this->getServiceManager()->propagate($packer);
-        return [
-            $packer->packTest($test)
-        ];
+        return $packer->packTest($test);
     }
 
     /**

--- a/model/tasks/PrintDelivery.php
+++ b/model/tasks/PrintDelivery.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+namespace oat\taoBooklet\model\tasks;
+
+use core_kernel_classes_Resource;
+use JsonSerializable;
+use oat\taoBooklet\model\BookletConfigService;
+use oat\taoBooklet\model\StorageService;
+use oat\taoQtiPrint\model\DeliveryPacker;
+
+/**
+ * Class PrintDeliveries
+ * @package oat\taoBooklet\model\tasks
+ */
+class PrintDelivery extends AbstractBookletTask
+{
+    /**
+     *
+     * @param array $params
+     * @return \common_report_Report
+     * @throws \common_exception_MissingParameter
+     */
+    public function __invoke($params)
+    {
+        // make sure the context is loaded
+        $extensionManager = $this->getServiceLocator()->get('generis/extensionManager');
+        $extensionManager->getExtensionById('taoDeliveryRdf');
+
+        return parent::__invoke($params);
+    }
+
+    /**
+     * Gets the list of mandatory parameters
+     * @return array
+     */
+    protected function getMandatoryParams()
+    {
+        return array_merge(parent::getMandatoryParams(), ['config']);
+    }
+
+    /**
+     * Gets the config for a booklet instance using either the instance itself or an array of properties
+     * @param core_kernel_classes_Resource $instance
+     * @return mixed
+     */
+    protected function getBookletConfig($instance)
+    {
+        $configService = $this->getServiceLocator()->get(BookletConfigService::SERVICE_ID);
+        $config = $configService->getConfig($this->getParam('config'));
+        return $config;
+    }
+
+    /**
+     * Gets the test definition data in order to print it
+     * @param core_kernel_classes_Resource $instance
+     * @return JsonSerializable|array
+     * @throws \Exception
+     */
+    protected function getTestData($instance)
+    {
+        $deliveryExecutionPacker = $this->getServiceLocator()->get(DeliveryPacker::SERVICE_ID);
+
+        return $deliveryExecutionPacker->getTestData($instance, $this->getParam('user'));
+    }
+
+    /**
+     * Stores the generated PDF file
+     * @param core_kernel_classes_Resource $instance
+     * @param string $filePath
+     * @return \common_report_Report
+     */
+    protected function storePdf($instance, $filePath)
+    {
+        $report = new \common_report_Report(\common_report_Report::TYPE_SUCCESS);
+
+        $storageService = $this->getServiceLocator()->get(StorageService::SERVICE_ID);
+        $fileResource = $storageService->storeFile($filePath);
+
+        $report->setMessage(__('%s rendered', $instance->getLabel()));
+        $report->setData($fileResource);
+        return $report;
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return __CLASS__;
+    }
+}

--- a/model/tasks/PrintResults.php
+++ b/model/tasks/PrintResults.php
@@ -41,7 +41,7 @@ use qtism\runtime\tests\RouteItem;
 use tao_helpers_Date;
 
 /**
- * Class UpdateBooklet
+ * Class PrintResults
  * @package oat\taoBooklet\model\tasks
  */
 class PrintResults extends AbstractBookletTask

--- a/model/tasks/PrintResults.php
+++ b/model/tasks/PrintResults.php
@@ -27,6 +27,7 @@ use oat\taoBooklet\model\BookletClassService;
 use oat\taoBooklet\model\BookletConfigService;
 use oat\taoBooklet\model\StorageService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoItems\model\pack\encoders\Base64fileEncoder;
 use oat\taoItems\model\pack\ExceptionMissingAsset;
 use oat\taoOutcomeUi\helper\ResponseVariableFormatter;
@@ -235,7 +236,7 @@ class PrintResults extends AbstractBookletTask
     protected function getDeliveryExecution()
     {
         if (!$this->deliveryExecution) {
-            $this->deliveryExecution = \taoDelivery_models_classes_execution_ServiceProxy::singleton()->getDeliveryExecution($this->getParam('id'));
+            $this->deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($this->getParam('id'));
         }
         return $this->deliveryExecution;
     }

--- a/model/tasks/PrintResults.php
+++ b/model/tasks/PrintResults.php
@@ -96,11 +96,19 @@ class PrintResults extends AbstractBookletTask
     {
         $deliveryExecutionPacker = $this->getServiceLocator()->get(DeliveryExecutionPacker::SERVICE_ID);
 
-        $uri = $this->getParam('uri'); 
-        $testData = $deliveryExecutionPacker->getTestData($uri);
-        $testData['states'] = $deliveryExecutionPacker->getResultVariables($uri);
+        $uris = $this->getParam('uri');
+        if (!is_array($uris)) {
+            $uris = [$uris];
+        }
+        $tests = [];
+        
+        foreach ($uris as $uri) {
+            $testData = $deliveryExecutionPacker->getTestData($uri);
+            $testData['states'] = $deliveryExecutionPacker->getResultVariables($uri);
+            $tests[] = $testData;
+        }
 
-        return $testData;
+        return $tests;
     }
 
     /**

--- a/model/tasks/PrintResults.php
+++ b/model/tasks/PrintResults.php
@@ -26,17 +26,8 @@ namespace oat\taoBooklet\model\tasks;
 use oat\taoBooklet\model\BookletClassService;
 use oat\taoBooklet\model\BookletConfigService;
 use oat\taoBooklet\model\StorageService;
-use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\ServiceProxy;
-use oat\taoItems\model\pack\encoders\Base64fileEncoder;
-use oat\taoItems\model\pack\ExceptionMissingAsset;
-use oat\taoOutcomeUi\helper\ResponseVariableFormatter;
-use oat\taoOutcomeUi\model\ResultsService;
-use oat\taoQtiItem\model\QtiJsonItemCompiler;
-use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
-use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
-use oat\taoQtiTest\models\TestSessionService;
-use oat\taoResultServer\models\classes\ResultServerService;
+use oat\taoQtiPrint\model\DeliveryExecutionPacker;
 use tao_helpers_Date;
 
 /**
@@ -46,19 +37,9 @@ use tao_helpers_Date;
 class PrintResults extends AbstractBookletTask
 {
     /**
-     * @var ResultsService
-     */
-    protected $resultsService;
-
-    /**
      * @var BookletClassService
      */
     protected $bookletClassService;
-
-    /**
-     * @var DeliveryExecution
-     */
-    protected $deliveryExecution;
 
     /**
      * AbstractBookletTask constructor.
@@ -66,7 +47,6 @@ class PrintResults extends AbstractBookletTask
     public function __construct()
     {
         $this->bookletClassService = BookletClassService::singleton();
-        $this->resultsService = ResultsService::singleton();
     }
 
     /**
@@ -91,15 +71,7 @@ class PrintResults extends AbstractBookletTask
      */
     protected function getMandatoryParams()
     {
-        return ['id', 'uri', 'user', 'config'];
-    }
-
-    /**
-     * @return ResultsService
-     */
-    protected function getResultsService()
-    {
-        return $this->resultsService;
+        return ['uri', 'user', 'config'];
     }
 
     /**
@@ -108,10 +80,11 @@ class PrintResults extends AbstractBookletTask
      */
     protected function getBookletConfig()
     {
+        $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($this->getParam('uri'));
         $configService = $this->getServiceLocator()->get(BookletConfigService::SERVICE_ID);
         $config = $configService->getConfig($this->getParam('config'));
         $config[BookletConfigService::CONFIG_REGULAR] = true;
-        $config[BookletConfigService::CONFIG_DATE] = tao_helpers_Date::displayeDate($this->getDeliveryExecution()->getStartTime());
+        $config[BookletConfigService::CONFIG_DATE] = tao_helpers_Date::displayeDate($deliveryExecution->getStartTime());
         return $config;
     }
 
@@ -121,94 +94,11 @@ class PrintResults extends AbstractBookletTask
      */
     protected function getTestData()
     {
-        $resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
-        $resultStorage = $resultServerService->getResultStorage($this->getParam('uri'));
-        $this->getResultsService()->setImplementation($resultStorage);
+        $deliveryExecutionPacker = $this->getServiceLocator()->get(DeliveryExecutionPacker::SERVICE_ID);
 
-        $resultId = $this->getParam('id');
-        $deliveryExecution = $this->getDeliveryExecution();
-
-        $userIdentifier = $deliveryExecution->getUserIdentifier();
-        $deliveryUser = new \core_kernel_users_GenerisUser(new \core_kernel_classes_Resource($userIdentifier));
-        $lang = $deliveryUser->getPropertyValues(PROPERTY_USER_DEFLG);
-        $userDataLang = empty($lang) ? DEFAULT_LANG : (string)current($lang);
-
-        $testSessionService = $this->getServiceLocator()->get(TestSessionService::SERVICE_ID);
-        /* @var \qtism\runtime\tests\AssessmentTestSession $testSession */
-        $testSession = $testSessionService->getTestSession($deliveryExecution);
-        $inputParameters = $testSessionService->getRuntimeInputParameters($deliveryExecution);
-        $fileStorage = \tao_models_classes_service_FileStorage::singleton();
-        $directoryIds = explode('|', $inputParameters['QtiTestCompilation']);
-        $compilationDirs = array(
-            'private' => $fileStorage->getDirectoryById($directoryIds[0]),
-            'public' => $fileStorage->getDirectoryById($directoryIds[1])
-        );
-        $assessmentTest = $testSession->getAssessmentTest();
-        $route = $testSession->getRoute();
-        $routeItems = $route->getAllRouteItems();
-        $lastPart = null;
-        $lastSection = null;
-        $testData = [
-            'type' => 'qtiprint',
-            'data' => [
-                'id' => $assessmentTest->getIdentifier(),
-                'uri' => $resultId,
-                'title' => $assessmentTest->getTitle(),
-                'testParts' => [],
-            ],
-            'items' => [],
-            'states' => $this->getResultVariables(),
-        ];
-
-        $rubricBlockHelper = $this->getServiceLocator()->get(QtiRunnerRubric::SERVICE_ID);
-        $config = $this->getServiceLocator()->get(QtiRunnerConfig::SERVICE_ID);
-        $reviewConfig = $config->getConfigValue('review');
-        $displaySubsectionTitle = isset($reviewConfig['displaySubsectionTitle']) ? (bool)$reviewConfig['displaySubsectionTitle'] : true;
-
-        foreach ($routeItems as $routeItem) {
-            $itemRef = $routeItem->getAssessmentItemRef();
-            $testPart = $routeItem->getTestPart();
-            $partId = $testPart->getIdentifier();
-
-            if ($displaySubsectionTitle) {
-                $section = $routeItem->getAssessmentSection();
-            } else {
-                $sections = $routeItem->getAssessmentSections()->getArrayCopy();
-                $section = $sections[0];
-            }
-            $sectionId = $section->getIdentifier();
-            $itemId = $itemRef->getIdentifier();
-            $itemUri = strstr($itemRef->getHref(), '|', true);
-
-            if ($lastPart != $partId) {
-                $lastPart = $partId;
-            }
-            if ($lastSection != $sectionId) {
-                $lastSection = $sectionId;
-            }
-
-            if (!isset($testData['data']['testParts'][$partId])) {
-                $testData['data']['testParts'][$partId] = [
-                    'id' => $partId,
-                    'sections' => [],
-                ];
-            }
-            if (!isset($testData['data']['testParts'][$partId]['sections'][$sectionId])) {
-                $testData['data']['testParts'][$partId]['sections'][$sectionId] = [
-                    'id' => $sectionId,
-                    'title' => $section->getTitle(),
-                    'rubricBlock' => $rubricBlockHelper->getRubricBlock($routeItem, $testSession, $compilationDirs),
-                    'items' => [],
-                ];
-            }
-
-            $testData['data']['testParts'][$partId]['sections'][$sectionId]['items'][] = [
-                'id' => $itemId,
-                'href' => $itemUri,
-            ];
-
-            $testData['items'][$itemUri] = $this->getItemData($itemRef->getHref(), $userDataLang);
-        }
+        $uri = $this->getParam('uri'); 
+        $testData = $deliveryExecutionPacker->getTestData($uri);
+        $testData['states'] = $deliveryExecutionPacker->getResultVariables($uri);
 
         return $testData;
     }
@@ -227,123 +117,6 @@ class PrintResults extends AbstractBookletTask
         $report->setMessage(__('%s rendered', $this->getInstance()->getLabel()));
         $report->setData($fileResource);
         return $report;
-    }
-
-    /**
-     * @return DeliveryExecution
-     */
-    protected function getDeliveryExecution()
-    {
-        if (!$this->deliveryExecution) {
-            $this->deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($this->getParam('id'));
-        }
-        return $this->deliveryExecution;
-    }
-
-    /**
-     * Extracts the result variables, with respect to the user's filter, and inject item states to allow preview with results
-     * @return array
-     */
-    protected function getResultVariables()
-    {
-        $resultId = $this->getParam('id');
-        $displayedVariables = $this->getResultsService()->getStructuredVariables($resultId, 'lastSubmitted', [\taoResultServer_models_classes_ResponseVariable::class]);
-        $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState($displayedVariables);
-        $excludedVariables = array_flip(['numAttempts', 'duration']);
-
-        $resultVariables = [];
-        foreach ($displayedVariables as &$item) {
-            if (!isset($item['uri'])) {
-                continue;
-            }
-            $itemUri = $item['uri'];
-            if (isset($responses[$itemUri])) {
-                $resultVariables[$itemUri] = array_diff_key($responses[$itemUri], $excludedVariables);
-                if (!count($resultVariables[$itemUri])) {
-                    $resultVariables[$itemUri] = null;
-                }
-            } else {
-                $resultVariables[$itemUri] = null;
-            }
-        }
-
-        return $resultVariables;
-    }
-
-    /**
-     * Gets the definition of an item
-     * @param string $itemRef
-     * @param string $userDataLang
-     * @return array
-     * @throws \common_Exception
-     * @throws \common_exception_InconsistentData
-     * @throws \tao_models_classes_FileNotFoundException
-     */
-    protected function getItemData($itemRef, $userDataLang)
-    {
-        $directoryIds = explode('|', $itemRef);
-        if (count($directoryIds) < 3) {
-            throw new \common_exception_InconsistentData('The itemRef is not formatted correctly');
-        }
-
-        $itemUri = $directoryIds[0];
-        $publicDirectory = \tao_models_classes_service_FileStorage::singleton()->getDirectoryById($directoryIds[1]);
-        $privateDirectory = \tao_models_classes_service_FileStorage::singleton()->getDirectoryById($directoryIds[2]);
-
-        if ($privateDirectory->has($userDataLang)) {
-            $lang = $userDataLang;
-        } elseif ($privateDirectory->has(DEFAULT_LANG)) {
-            \common_Logger::i(
-                $userDataLang . ' is not part of compilation directory for item : ' . $itemUri . ' use ' . DEFAULT_LANG
-            );
-            $lang = DEFAULT_LANG;
-        } else {
-            throw new \common_Exception(
-                'item : ' . $itemUri . 'is neither compiled in ' . $userDataLang . ' nor in ' . DEFAULT_LANG
-            );
-        }
-
-        $fileName = QtiJsonItemCompiler::ITEM_FILE_NAME;
-        try {
-            return $this->resolveAssets(
-                json_decode($privateDirectory->read($lang . DIRECTORY_SEPARATOR . $fileName), true),
-                $publicDirectory,
-                $lang
-            );
-        } catch (\FileNotFoundException $e) {
-            throw new \tao_models_classes_FileNotFoundException(
-                $fileName . ' for item reference ' . $itemRef
-            );
-        }
-    }
-
-    /**
-     * @param array $itemData
-     * @param \tao_models_classes_service_StorageDirectory $publicDirectory
-     * @param string $lang
-     * @return array
-     */
-    protected function resolveAssets($itemData, $publicDirectory, $lang)
-    {
-        $itemData['baseUrl'] = $publicDirectory->getPublicAccessUrl() . $lang . '/';
-        $encoder = new Base64fileEncoder($publicDirectory);
-
-        $allowedTypes = ['img', 'css'];
-
-        if (isset($itemData['assets'])) {
-            foreach ($itemData['assets'] as $type => &$assets) {
-                if (in_array($type, $allowedTypes)) {
-                    foreach ($assets as $uri => $asset) {
-                        try {
-                            $assets[$uri] = $encoder->encode($lang . '/' . $asset);
-                        } catch (ExceptionMissingAsset $e) {
-                        }
-                    }
-                }
-            }
-        }
-
-        return $itemData;
     }
 
     /**

--- a/scripts/install/booklet.rdf
+++ b/scripts/install/booklet.rdf
@@ -129,6 +129,11 @@
         <rdfs:comment xml:lang="en-US"><![CDATA[Display the QR-code on the cover page]]></rdfs:comment>
         <rdf:type rdf:resource="http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageOptions"/>
     </rdf:Description>
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageUniqueId">
+        <rdfs:label xml:lang="en-US"><![CDATA[Unique identifier]]></rdfs:label>
+        <rdfs:comment xml:lang="en-US"><![CDATA[Display unique identifier of the booklet]]></rdfs:comment>
+        <rdf:type rdf:resource="http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageOptions"/>
+    </rdf:Description>
 
     <rdf:Description rdf:about="http://www.tao.lu/Ontologies/Booklet.rdf#PageHeader">
         <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
@@ -182,6 +187,11 @@
     <rdf:Description rdf:about="http://www.tao.lu/Ontologies/Booklet.rdf#PageNumber">
         <rdfs:label xml:lang="en-US"><![CDATA[Page number]]></rdfs:label>
         <rdfs:comment xml:lang="en-US"><![CDATA[Display the page number]]></rdfs:comment>
+        <rdf:type rdf:resource="http://www.tao.lu/Ontologies/Booklet.rdf#PageOptions"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/Booklet.rdf#PageUniqueId">
+        <rdfs:label xml:lang="en-US"><![CDATA[Unique identifier]]></rdfs:label>
+        <rdfs:comment xml:lang="en-US"><![CDATA[Display unique identifier of the booklet]]></rdfs:comment>
         <rdf:type rdf:resource="http://www.tao.lu/Ontologies/Booklet.rdf#PageOptions"/>
     </rdf:Description>
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -144,7 +144,12 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('1.6.0');
         }
+        
+        if ($this->isVersion('1.6.0')) {
 
-        $this->skip('1.6.0', '1.7.0');
+            OntologyUpdater::syncModels();
+
+            $this->setVersion('1.7.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -144,5 +144,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('1.6.0');
         }
+
+        $this->skip('1.6.0', '1.7.0');
     }
 }

--- a/views/templates/PrintTest/line.js
+++ b/views/templates/PrintTest/line.js
@@ -81,6 +81,10 @@ function subst(type) {
             addCellContent('middle', wrap(vars.doctitle));
         }
 
+        if (lineConfig.unique_id && config.unique_id) {
+            addCellContent('right', wrap(config.unique_id));
+        }
+
         if (lineConfig.date && vars.date) {
             addCellContent('right', wrap(vars.date));
         }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4793

Requires: https://github.com/oat-sa/extension-tao-qtiprint/pull/32

The purpose of this PR is to support the printing of a booklet from several instances (`AssessmentTest`, `Delivery`, `DeliveryExecution`). The provided tasks are only taking care of one instance to print, but the engine behind is able to carry on mon than one.

To print a booklet from several instances, you just need to create a task and provide the list of instances to print as an array of URI. You may also set the main instance (say the main instance that will give a name to the booklet and the place to link the result file). If no main instance is provided, the first of the provided instances will be considered as the main.

For instance, here is a sample that creates a booklet from 3 deliveries:

```php
$action = new PrintDelivery();
$this->getServiceManager()->propagate($action);
$label = "Booklet from 3 deliveries";
$instanceUri = 'http://tao.dev/trololo#123456';
$queueParameters = [
    'root' => $instanceUri,
    'uri' => [$deliveryUri1, $deliveryUri2, $deliveryUri3],
    'user' => common_session_SessionManager::getSession()->getUserUri(),
    'config' => $printConfig, // should come from a form, like the `printWizard` action will provide
];

// the result file will be added as the task report data
$task = $this->getQueueService()->createTask($action, $queueParameters, false, $label, $instanceUri);
```

- Refactors a little the print tasks: move the test definition extractors into the companion extension taoQtiPrint (`DeliveryPacker` and `DeliveryExecutionPacker`).
- Add an option to print a unique identifier on headers and footers.
- The print tasks can now handle a list of tests/deliveries/deliveryExecutions instead of only one. To do so, when more than one instance is to be printed, the task will generate separately PDF for each one, then bundle all into one file using an external library (`jurosh/pdf-merge`).
