### PR TITLE
Fix/tao 4144 cover page qr code

### DIFF
--- a/form/WizardPrintForm.php
+++ b/form/WizardPrintForm.php
@@ -36,5 +36,14 @@ class WizardPrintForm extends GenerateForm
         parent::initElements();
 
         $this->getForm()->removeElement( tao_helpers_Uri::encode( BookletClassService::PROPERTY_TEST ) );
+
+        // the QR code is only compatible with booklet instances
+        $coverPage = $this->getForm()->getElement( tao_helpers_Uri::encode( BookletClassService::PROPERTY_COVER_PAGE ) );
+        $options = $coverPage->getOptions();
+        $qrcode = tao_helpers_Uri::encode( BookletClassService::INSTANCE_COVER_PAGE_QRCODE );
+        if (isset($options[$qrcode])) {
+            unset($options[$qrcode]);
+            $coverPage->setOptions($options);
+        }
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -24,12 +24,12 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.9.3',
+    'version'     => '1.10.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'          => '>=10.2.0',
         'taoQtiTest'   => '>=7.0.0',
-        'taoQtiPrint'  => '>=1.4.0',
+        'taoQtiPrint'  => '>=1.5.0',
         'taoOutcomeUi' => '>=4.5.0',
     ),
     // for compatibility

--- a/model/BookletConfigService.php
+++ b/model/BookletConfigService.php
@@ -68,6 +68,8 @@ class BookletConfigService extends ConfigurableService
     const CONFIG_DATE = 'date';
     const CONFIG_LOGO = 'logo';
     const CONFIG_QRCODE = 'qr_code';
+    const CONFIG_QRCODE_DATA = 'qr_code_data';
+    const CONFIG_URI = 'uri';
     const CONFIG_MENTION = 'mention';
     const CONFIG_LINK = 'link';
     const CONFIG_PAGE_NUMBER = 'page_number';
@@ -246,6 +248,10 @@ class BookletConfigService extends ConfigurableService
                 $this->getOption(self::OPTION_CUSTOM_ID_STRING),
                 $externalDataProvider->getCustomId()
             );
+        }
+
+        if ($instance instanceof core_kernel_classes_Resource) {
+            $config[self::CONFIG_URI] = $instance->getUri();
         }
 
         return $config;

--- a/model/tasks/AbstractBookletTask.php
+++ b/model/tasks/AbstractBookletTask.php
@@ -110,6 +110,7 @@ abstract class AbstractBookletTask extends AbstractTaskAction implements JsonSer
             $instance = $this->getResource($uri);
 
             $config = $this->getBookletConfig($instance);
+            $config[BookletConfigService::CONFIG_URI] = $uri;
             $storageKey = $this->cacheBookletData($uri, [
                 'testData' => $this->getTestData($instance),
                 'config' => $config,

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -144,7 +144,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('1.6.0');
         }
-        
+
         if ($this->isVersion('1.6.0')) {
 
             OntologyUpdater::syncModels();
@@ -170,6 +170,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('1.9.1');
         }
 
-        $this->skip('1.9.1', '1.9.3');
+        $this->skip('1.9.1', '1.10.0');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4144

Requires: https://github.com/oat-sa/extension-tao-qtiprint/pull/36

The QR code displayed on the cover page contains the URL of the booklet. However the provided URI was related to the test... And the resulting page was incorrect.

Now this URL targets the booklet itself, by using its URI.
However this feature is only compatible with booklets instances, not with the results prints.
For this reason, the QR code option has been removed from the print form related to results.