### PR TITLE
Feature/tao 5233 booklet variable names

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'requires'    => array(
         'tao'          => '>=10.2.0',
         'taoQtiTest'   => '>=7.0.0',
-        'taoQtiPrint'  => '>=1.5.0',
+        'taoQtiPrint'  => '>=1.6.0',
         'taoOutcomeUi' => '>=4.5.0',
     ),
     // for compatibility

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '1.10.1',
+    'version'     => '1.11.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'          => '>=10.2.0',

--- a/model/BookletClassService.php
+++ b/model/BookletClassService.php
@@ -46,6 +46,7 @@ class BookletClassService extends tao_models_classes_ClassService
     const INSTANCE_LAYOUT_ONE_PAGE_ITEM = 'http://www.tao.lu/Ontologies/Booklet.rdf#OnePageItem';
     const INSTANCE_LAYOUT_BLANK_PAGES = 'http://www.tao.lu/Ontologies/Booklet.rdf#BlankPages';
     const INSTANCE_LAYOUT_BUBBLE_SHEET = 'http://www.tao.lu/Ontologies/Booklet.rdf#BubbleSheet';
+    const INSTANCE_LAYOUT_SHOW_RESPONSE_IDENTIFIER = 'http://www.tao.lu/Ontologies/Booklet.rdf#ShowResponseIdentifier';
 
     const INSTANCE_COVER_PAGE_TITLE = 'http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageTitle';
     const INSTANCE_COVER_PAGE_DESCRIPTION = 'http://www.tao.lu/Ontologies/Booklet.rdf#CoverPageDescription';

--- a/model/BookletConfigService.php
+++ b/model/BookletConfigService.php
@@ -61,6 +61,7 @@ class BookletConfigService extends ConfigurableService
     const CONFIG_PAGE_FOOTER = 'page_footer';
     const CONFIG_ONE_PAGE_ITEM = 'one_page_item';
     const CONFIG_ONE_PAGE_SECTION = 'one_page_section';
+    const CONFIG_SHOW_RESPONSE_IDENTIFIER = 'show_response_identifier';
     const CONFIG_BLANK_PAGES = 'add_blank_pages';
     const CONFIG_BUBBLE_SHEET = 'use_bubble_sheet';
     const CONFIG_TITLE = 'title';
@@ -116,6 +117,7 @@ class BookletConfigService extends ConfigurableService
         BookletClassService::INSTANCE_LAYOUT_ONE_PAGE_SECTION => self::CONFIG_ONE_PAGE_SECTION,
         BookletClassService::INSTANCE_LAYOUT_BLANK_PAGES => self::CONFIG_BLANK_PAGES,
         BookletClassService::INSTANCE_LAYOUT_BUBBLE_SHEET => self::CONFIG_BUBBLE_SHEET,
+        BookletClassService::INSTANCE_LAYOUT_SHOW_RESPONSE_IDENTIFIER => self::CONFIG_SHOW_RESPONSE_IDENTIFIER,
 
         BookletClassService::INSTANCE_COVER_PAGE_TITLE => self::CONFIG_TITLE,
         BookletClassService::INSTANCE_COVER_PAGE_DESCRIPTION => self::CONFIG_DESCRIPTION,

--- a/scripts/install/booklet.rdf
+++ b/scripts/install/booklet.rdf
@@ -82,6 +82,12 @@
         <rdf:type rdf:resource="http://www.tao.lu/Ontologies/Booklet.rdf#LayoutOptions"/>
     </rdf:Description>
 
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/Booklet.rdf#ShowResponseIdentifier">
+        <rdfs:label xml:lang="en-US"><![CDATA[Show Response Identifier]]></rdfs:label>
+        <rdfs:comment xml:lang="en-US"><![CDATA[Show the interaction's response identifier]]></rdfs:comment>
+        <rdf:type rdf:resource="http://www.tao.lu/Ontologies/Booklet.rdf#LayoutOptions"/>
+    </rdf:Description>
+
     <rdf:Description rdf:about="http://www.tao.lu/Ontologies/Booklet.rdf#OnePageItem">
         <rdfs:label xml:lang="en-US"><![CDATA[One Item per page]]></rdfs:label>
         <rdfs:comment xml:lang="en-US"><![CDATA[Place each Item on a dedicated page]]></rdfs:comment>

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -171,5 +171,12 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('1.9.1', '1.10.1');
+
+        if ($this->isVersion('1.10.1')) {
+
+            OntologyUpdater::syncModels();
+
+            $this->setVersion('1.11.0');
+        }
     }
 }


### PR DESCRIPTION
Added the new option "Show Response Identifier" to the booklet property form to optionally display the response identifier of an interaction in the booklet generation.

Requires https://github.com/oat-sa/extension-tao-qtiprint/pull/38