### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,10 +24,10 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '2.1.1',
+    'version'     => '2.2.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
-        'tao'          => '>=21.15.0',
+        'tao'          => '>=30.0.0',
         'taoQtiTest'   => '>=29.0.0',
         'taoQtiPrint'  => '>=1.6.0',
         'taoOutcomeUi' => '>=7.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '2.1.0',
+    'version'     => '2.1.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'          => '>=21.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -179,6 +179,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('1.12.0');
         }
 
-        $this->skip('1.12.0', '2.1.0');
+        $this->skip('1.12.0', '2.1.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -179,6 +179,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('1.12.0');
         }
 
-        $this->skip('1.12.0', '2.1.1');
+        $this->skip('1.12.0', '2.2.0');
     }
 }

--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -1,0 +1,39 @@
+module.exports = function(grunt) {
+    'use strict';
+
+    var testUrl     = 'http://127.0.0.1:' + grunt.option('testPort');
+    var root        = grunt.option('root');
+
+    var testRunners = root + '/taoBooklet/views/js/test/**/test.html';
+    var testFiles   = root + '/taoBooklet/views/js/test/**/test.js';
+
+    //extract unit tests
+    var extractTests = function extractTests(){
+        return grunt.file.expand([testRunners]).map(function(path){
+            return path.replace(root, testUrl);
+        });
+    };
+
+    grunt.config.merge({
+        qunit: {
+            taobooklet : {
+                options: {
+                    console : true,
+                    urls : extractTests()
+                }
+            }
+        },
+        watch: {
+            taobooklettest : {
+                files : [testRunners, testFiles],
+                tasks : ['qunit:taobooklet'],
+                options : {
+                    debounceDelay : 10000
+                }
+            }
+        }
+    });
+
+    // register main test task
+    grunt.registerTask('taobooklettest', ['qunit:taobooklet']);
+};

--- a/views/js/test/runner/testRunner/test.html
+++ b/views/js/test/runner/testRunner/test.html
@@ -7,8 +7,8 @@
 
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="testRunner.js"></script>
 
         <script  type="text/javascript">

--- a/views/js/test/runner/testRunner/test.html
+++ b/views/js/test/runner/testRunner/test.html
@@ -15,15 +15,15 @@
 
             //don't start the test now
             QUnit.config.autostart = false;
+            QUnit.config.reorder = false;
+
 
             //load the config
             require(['/tao/ClientConfig/config'], function(){
 
                 //load the test
                 require(['taoBooklet/test/runner/testRunner/test'], function(){
-
                     //Tests loaded, run tests
-                    QUnit.config.reorder = false;
                     QUnit.start();
                 });
             });

--- a/views/js/test/runner/testRunner/test.js
+++ b/views/js/test/runner/testRunner/test.js
@@ -1,29 +1,29 @@
-define( [
+define([
 
     'jquery',
     'taoBooklet/runner/testRunner',
     'json!taoBooklet/test/samples/test.json'
-], function(  $, testRunner, testData ) {
+], function($, testRunner, testData) {
 
     var container = 'outside-container';
 
-    QUnit.module( 'Runner API' );
+    QUnit.module('Runner API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.ok( typeof testRunner !== 'undefined', 'The module exports something' );
-        assert.ok( typeof testRunner === 'function', 'The module exports a function' );
-    } );
+    QUnit.test('module', function(assert) {
+        assert.ok(typeof testRunner !== 'undefined', 'The module exports something');
+        assert.ok(typeof testRunner === 'function', 'The module exports a function');
+    });
 
-    QUnit.module( 'Render' );
+    QUnit.module('Render');
 
-    QUnit.test( 'module', function( assert ) {
+    QUnit.test('module', function(assert) {
         var ready = assert.async();
-        assert.expect( 1 );
-        testRunner( $( '.' + container ), testData );
-        setTimeout( function() {
-            assert.ok( true );
+        assert.expect(1);
+        testRunner($('.' + container), testData);
+        setTimeout(function() {
+            assert.ok(true);
             ready();
-        }, 1000 );
-    } );
-} );
+        }, 1000);
+    });
+});
 

--- a/views/js/test/runner/testRunner/test.js
+++ b/views/js/test/runner/testRunner/test.js
@@ -1,28 +1,29 @@
-define([
+define( [
+
     'jquery',
     'taoBooklet/runner/testRunner',
     'json!taoBooklet/test/samples/test.json'
-], function($, testRunner, testData){
+], function(  $, testRunner, testData ) {
 
     var container = 'outside-container';
 
-    QUnit.module('Runner API');
+    QUnit.module( 'Runner API' );
 
-    QUnit.test('module', function(assert){
-        assert.ok(typeof testRunner !== 'undefined', "The module exports something");
-        assert.ok(typeof testRunner === 'function', "The module exports a function");
-    });
+    QUnit.test( 'module', function( assert ) {
+        assert.ok( typeof testRunner !== 'undefined', 'The module exports something' );
+        assert.ok( typeof testRunner === 'function', 'The module exports a function' );
+    } );
 
+    QUnit.module( 'Render' );
 
-    QUnit.module('Render');
-
-    QUnit.asyncTest('module', function(assert){
-        QUnit.expect(1);
-        testRunner($('.' + container), testData);
-        setTimeout(function(){
-            assert.ok(true);
-            QUnit.start();
-        }, 1000);
-    });
-});
+    QUnit.test( 'module', function( assert ) {
+        var ready = assert.async();
+        assert.expect( 1 );
+        testRunner( $( '.' + container ), testData );
+        setTimeout( function() {
+            assert.ok( true );
+            ready();
+        }, 1000 );
+    } );
+} );
 


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description**  convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs** 
https://github.com/oat-sa/extension-tao-xmledit/pull/18
https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-task-queue/pull/83
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-qtiprint/pull/56
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-clientdiag/pull/223
https://github.com/oat-sa/extension-tao-blueprints/pull/20
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
https://github.com/oat-sa/extension-pcisample/pull/44