### PR TITLE
Fix/nec-81/uninformative error when save booklet without require params

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '3.4.1',
+    'version'     => '3.4.2',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis' => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -194,6 +194,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.2.0');
         }
 
-        $this->skip('3.2.0', '3.4.1');
+        $this->skip('3.2.0', '3.4.2');
     }
 }

--- a/views/js/controller/Booklet/wizard.js
+++ b/views/js/controller/Booklet/wizard.js
@@ -89,7 +89,7 @@ define([
                 refreshTree();
             }).on('error', function(err){
                 //format and display error message to user
-                feedback().error(err);
+                feedback().error(err.errorMessage);
                 // refreshTree();
                 $('#booklet-new a').click();
             }).render($oldSubmitter.closest('.form-toolbar'));


### PR DESCRIPTION
___Related to task:___ https://oat-sa.atlassian.net/browse/NEC-81

___Description:___ Uninformative error when trying to save a booklet with no Test selected

___How to test:___ 
1. Log in as Authoring Admin
2. Go to Booklets tab
3. Click "New Booklet"
4. Type in the Label
5. Press the Save button

Fixed parameter passed for correct error display