### PR TITLE
Feature/BSA-164/shared stimulus in Booklet

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "minimum-stability" : "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "mikehaertl/phpwkhtmltopdf": "dev-master",
+        "mikehaertl/phpwkhtmltopdf": "^2.4",
         "tecnickcom/tcpdf": "^6.2",
-        "jurosh/pdf-merge": "dev-master"
+        "jurosh/pdf-merge": "^2.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '3.5.0',
+    'version'     => '3.6.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis' => '>=12.15.0',

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -33,7 +33,8 @@ module.exports = function(grunt) {
                     bundles : [{
                         name : 'taoBooklet',
                         default : true,
-                        bootstrap : true
+                        bootstrap : true,
+                        babel : true
                     }]
                 }
             }

--- a/views/js/controller/PrintTest/render.js
+++ b/views/js/controller/PrintTest/render.js
@@ -116,7 +116,7 @@ define([
             const href = $include.attr('data-href');
             if (!hrefs[href]) {
                 hrefs[href] = true;
-                const $section = $include.parents('section');
+                const $section = $include.closest('section.item');
                 // move shared stimulus in section before item
                 const $newSection = $('<section class="grid-row include"></section>');
                 $newSection.append($include);

--- a/views/js/controller/PrintTest/render.js
+++ b/views/js/controller/PrintTest/render.js
@@ -41,11 +41,12 @@ define([
      */
     function showMessage(msg, type) {
         type = type || 'info';
-        $('body').append('<div class="feedback-' + type + '">' + msg + '</div>');
+        $('body').append(`<div class="feedback-${type}">${msg}</div>`);
     }
 
     /**
      * Hack the current layout to match arbitrary rules
+     * @param {JQuery} $container
      */
     function printLayoutHacking($container) {
 
@@ -103,6 +104,31 @@ define([
     }
 
     /**
+     * Extract shared stimulus from a item, put it in section before a item
+     * Remove repeated shared stimulus
+     * @param {JQuery} $container
+     */
+    function extractSharedStimulus($container) {
+        const hrefs = {};
+        // find shared stimulus
+        $container.find('.qti-include').each(function () {
+            const $include = $(this);
+            const href = $include.attr('data-href');
+            if (!hrefs[href]) {
+                hrefs[href] = true;
+                const $section = $include.parents('section');
+                // move shared stimulus in section before item
+                const $newSection = $('<section class="grid-row include"></section>');
+                $newSection.append($include);
+                $section.before($newSection);
+            } else {
+                // each shared stimulus is included only once
+                $include.remove();
+            }
+        });
+    }
+
+    /**
      * The renderer controller
      * @exports taoBooklet/controller/printTest/render
      */
@@ -110,8 +136,7 @@ define([
 
         /**
          * Controller entry point
-         * @param {Object} testData - the packed test data required by the testRunner
-         * @param {Object} options
+         * @param {Object} config
          */
         start: function start(config) {
             var testData = config.testData;
@@ -163,6 +188,8 @@ define([
                     if (layoutOptions['add_blank_pages']) {
                         printLayoutHacking($mainContainer);
                     }
+
+                    extractSharedStimulus($mainContainer);
 
                     clearTimeout(timeout);
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/BSA-164

**Related to: https://github.com/oat-sa/extension-tao-qtiprint/pull/70**

Added render for `qtiClass: include` (Shared Stimulus)
Added styles for `section.include`

How to test:
1. install `wkhtmltopdf` https://hub.taotesting.com/techdocs/tao-booklet/readme-booklet
2. set `define('DEBUG_MODE', false);` in `config/generis.conf.php`
3. in `config/taoBooklet/wkhtmltopdf.conf.php` set binary to wkhtmltopdf path for example `'binary' => '/usr/local/bin/wkhtmltopdf',`
3. compile bundles for taoQtiPrint and taoBooklet
`cd tao/views/build`
`npx grunt taoqtiprintbundle` 
`npx grunt taobookletbundle` 
4. create shared stimulus
5. create items with shared stimulus
6. create test with these items
7. generate booklet from test
8. open booklet in preview and download pdf
9. Should be: 

- each shared stimulus is included only once in the booklet, 
- a shared stimulus is included in the booklet before the first item referencing it, 
- a shared stimulus is always followed by a page break, 
- a shared stimulus is always preceded by a page break