### PR TITLE
Fix/CON-144/Booklet preview fails due to timeout

### DIFF
--- a/controller/PrintTest.php
+++ b/controller/PrintTest.php
@@ -84,7 +84,7 @@ class PrintTest extends tao_actions_CommonModule
                 throw new \common_exception_NotFound('Not a QTI test');
             }
 
-            $packer = $this->propagate(new QtiTestPacker());
+            $packer = $this->propagate(new QtiTestPacker(true));
             $configService = $this->getServiceLocator()->get(BookletConfigService::SERVICE_ID);
             $bookletData = [
                 'testData' => $packer->packTest($test),

--- a/manifest.php
+++ b/manifest.php
@@ -28,13 +28,13 @@ return [
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '3.7.2',
+    'version'     => '3.7.3',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis' => '>=12.15.0',
         'tao'          => '>=30.0.0',
         'taoQtiTest'   => '>=29.0.0',
-        'taoQtiPrint'  => '>=1.9.0',
+        'taoQtiPrint'  => '>=1.15.0',
         'taoOutcomeUi' => '>=7.0.0',
     ],
     // for compatibility


### PR DESCRIPTION
**Relates to:** [CON-144](https://oat-sa.atlassian.net/browse/CON-144)

**Changes:** `QtiTestPacker` was configured to skip validation.

**Require PR:** [oat-sa/extension-tao-qtiprint#82](https://github.com/oat-sa/extension-tao-qtiprint/pull/82)

**Companion PRs:**
* [oat-sa/extension-tao-item#449](https://github.com/oat-sa/extension-tao-item/pull/449)
* [oat-sa/extension-tao-itemqti#1607](https://github.com/oat-sa/extension-tao-itemqti/pull/1607)

**How to test:**
1. Create or import a large test (15+ items);
2. Generate a booklet;
3. Open this booklet and preview it.

**Previous result:** _the preview takes a long time (~1.5 seconds per item)._
**Current result:** _the preview takes a short time (1-3 seconds for the whole test)._