### PR TITLE
Fix/CON-59/Pdf file contains wrong title and labels

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'label'       => 'Test Booklets',
     'description' => 'An extension for TAO to create test booklets (publishable in MS-Word and PDF along with Answer Sheets)',
     'license'     => 'GPL-2.0',
-    'version'     => '3.7.3',
+    'version'     => '3.7.4',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis' => '>=12.15.0',

--- a/model/tasks/AbstractBookletTask.php
+++ b/model/tasks/AbstractBookletTask.php
@@ -116,7 +116,11 @@ abstract class AbstractBookletTask extends AbstractAction implements JsonSeriali
 
             $config = $this->getBookletConfig($instance);
             $config[BookletConfigService::CONFIG_URI] = $uri;
-            $config[BookletConfigService::CONFIG_TITLE] = $this->getParam('label');
+            $config[BookletConfigService::CONFIG_TITLE] = filter_var(
+                $this->getParam('label'),
+                FILTER_SANITIZE_STRING
+            );
+
             $storageKey = $this->cacheBookletData($uri, [
                 'testData' => $this->getTestData($instance),
                 'config' => $config,

--- a/model/tasks/AbstractBookletTask.php
+++ b/model/tasks/AbstractBookletTask.php
@@ -116,6 +116,7 @@ abstract class AbstractBookletTask extends AbstractAction implements JsonSeriali
 
             $config = $this->getBookletConfig($instance);
             $config[BookletConfigService::CONFIG_URI] = $uri;
+            $config[BookletConfigService::CONFIG_TITLE] = $this->getParam('label');
             $storageKey = $this->cacheBookletData($uri, [
                 'testData' => $this->getTestData($instance),
                 'config' => $config,


### PR DESCRIPTION
**Relates to:** [CON-59](https://oat-sa.atlassian.net/browse/CON-59)

**Changes**: config property `title` was changes from 'in progress' to the Label typed by user.

**How to test:**
1. Generate a new Booklet or regenerate the previous one
2. Download the PDF file and open it
3. Take a look on the tab Title
4. Take a look on the middle top of each page

**Previous result:** _tab title and words in the middle of each page are `"in progress"`._
![image](https://user-images.githubusercontent.com/59471572/105493582-a406f280-5cca-11eb-938a-797f2b23f1b4.png)

**Current result:** _tab title and words in the middle of each page are Label which was typed by user._
![image](https://user-images.githubusercontent.com/59471572/105493602-a9fcd380-5cca-11eb-819e-b2e99b2aced8.png)