### PR TITLE
chore: Require tao-core version including the section whitelist in the Advanced Search endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "tecnickcom/tcpdf": "^6.2",
         "jurosh/pdf-merge": "^2.0",
         "oat-sa/generis" : ">=14.0.0",
-        "oat-sa/tao-core" : ">=47.0.0",
+        "oat-sa/tao-core" : ">=49.0.0",
         "oat-sa/extension-tao-delivery" : ">=15.0.0",
         "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
         "oat-sa/extension-tao-outcome" : ">=13.0.0",


### PR DESCRIPTION
**Associated Jira issue:** [ADF-245](https://oat-sa.atlassian.net/browse/ADF-245).

This sets the minimum required `tao-core` version in `composer.json` to the first one including the section whitelist on the responses from the Advanced Search status endpoint (`/tao/AdvancedSearch/status`).

That response is used by the frontend code from https://github.com/oat-sa/tao-core-ui-fe/releases/tag/v1.49.4 to handle Booklets as a section to hide advanced search controls from.