### PR TITLE
Feature/ADF-1245/Add a standalone ES5 bundle

### DIFF
--- a/views/templates/PrintTest/render.tpl
+++ b/views/templates/PrintTest/render.tpl
@@ -1,10 +1,16 @@
 <?php
-use oat\tao\helpers\Layout;
 use oat\tao\helpers\Template;
+use oat\tao\model\layout\AmdLoader;
+
+$configUrl    = get_data('client_config_url');
+$requireJsUrl = Template::js('lib/require.js', 'tao');
+$bootstrapUrl = Template::js('loader/bootstrap.js', 'tao');
+
+$loader = new AmdLoader($configUrl, $requireJsUrl, $bootstrapUrl);
 ?><!doctype html>
 <html>
 <head>
-    <?= Layout::getAmdLoader(Template::js('loader/taoBooklet.min.js', 'taoBooklet'), 'taoBooklet/controller/PrintTest/render', get_data('client_params'), true) ?>
+    <?= $loader->getBundleLoader(Template::js('loader/taoBookletRunner.min.js', 'taoBooklet'), 'taoBooklet/controller/PrintTest/render', get_data('client_params')); ?>
 </head>
 <body>
 </body>


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1245

### Summary

Add a dedicated JavaScript bundle compiled to ES5 so that the booklet can be printed by `wkhtmltopdf` without a runtime error.

### Details

This pull request is mostly a PoC and it contains 2 things:
- A standalone bundle containing all that is needed to process the booklet. This bundle is a handmade concatenation of the regular TAO bundles, but compiled to ES5. It contains: `vendor.min.js`, `taoItems.min.js`, `taoQtiItem.min.js`, `taoQtiPrint.min.js`, `taoBooklet.min.js`.
- A modification of the rendering view, in order to not load the default pipeline using cascaded bundles but a single and standalone bundle instead. The approach may not look as elegant as it would, because the code is a duplication of what is done under the hood by the helper `Layout::getAmdLoader`, without including the default bundles. A better approach would be to modify the helper for supporting the use case.

The next pull request will transform the PoC into a proper solution, using the TAO tool chain to produce the bundle and to include it properly into the page.

### How to test
- install taoBooklet (you need `wkhtmltopdf` with the QT patch)
- check out the branch
- create/update a booklet
- the PDF should be generated properly
- the preview should also work seamlessly.