### PR TITLE
fix: bump version with fix qtiPrint extn

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "oat-sa/extension-tao-outcome" : ">=13.0.0",
         "oat-sa/extension-tao-outcomeui" : ">=10.0.0",
         "oat-sa/extension-tao-test" : ">=15.0.0",
-        "oat-sa/extension-tao-qtiprint" : ">=2.0.0"
+        "oat-sa/extension-tao-qtiprint" : ">=3.1.2"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/BSA-344


Update of dependency in `tao-qtiPint` extension to fixed version
https://github.com/oat-sa/extension-tao-qtiprint/pull/96