### PR TITLE
fix: stick to minor version update taoQtiPrint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "oat-sa/extension-tao-outcome" : ">=13.0.0",
         "oat-sa/extension-tao-outcomeui" : ">=10.0.0",
         "oat-sa/extension-tao-test" : ">=15.0.0",
-        "oat-sa/extension-tao-qtiprint" : ">=3.1.2"
+        "oat-sa/extension-tao-qtiprint" : "~3.1.3"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1276

### Description
To fix image sizes for choices in generated booklets minSize needs to be specified for taoQtiPrint, PR refers the minor release

### How to test 
test with https://github.com/oat-sa/tao-enterprise-bosa