### PR TITLE
[WIP] LSI-4790/correctly render form

### DIFF
--- a/controller/Booklet.php
+++ b/controller/Booklet.php
@@ -204,17 +204,13 @@ class Booklet extends AbstractBookletController
      */
     public function wizard()
     {
-        $fromTest = false;
-        if ($this->isRequestComingFromTests()) {
-            $fromTest = true;
-        }
         $this->defaultData();
 
         try {
             $test = null;
             $currentClass = $this->getCurrentClass();
 
-            if ($fromTest) {
+            if ($this->isRequestComingFromTests()) {
                 $currentClass = $this->getRootClass();
                 try {
                     $test = $this->getCurrentInstance();

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -66,7 +66,7 @@
         <sections>
             <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                 <actions allowClassActions="true">
-                    <action id="test-booklet" name="New booklet" url="taoBooklet/Booklet/testBooklet" context="instance" group="tree">
+                    <action id="test-booklet" name="New booklet" url="taoBooklet/Booklet/wizard" context="instance" group="tree">
                         <icon id="icon-delivery"/>
                     </action>
                 </actions>


### PR DESCRIPTION
ticket: https://oat-sa.atlassian.net/browse/LSI-4790

Combining two endpoints under a single URL to ensure they function properly. The issue is that one of the endpoints does not serve scripts. Because of this, after submitting the form and creating the booklet, even though it returns JSON with a response, it is not rendered correctly and just gets displayed in place of the form.